### PR TITLE
First version of template engine for iofog

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "helmet": "3.21.2",
     "is-elevated": "3.0.0",
     "jsonschema": "1.2.5",
+    "liquidjs": "^9.16.1",
     "moment": "2.24.0",
     "morgan": "1.9.1",
     "nconf": "0.10.0",

--- a/src/helpers/template-helper.js
+++ b/src/helpers/template-helper.js
@@ -30,8 +30,6 @@ const rvaluesVarSubstition = async (subjects, templateContext) => {
   return subjects
 }
 
-
-
 module.exports = {
   rvaluesVarSubstition
 }

--- a/src/helpers/template-helper.js
+++ b/src/helpers/template-helper.js
@@ -1,0 +1,37 @@
+/*
+ *  *******************************************************************************
+ *  * Copyright (c) 2020 Edgeworx, Inc.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Eclipse Public License v. 2.0 which is available at
+ *  * http://www.eclipse.org/legal/epl-2.0
+ *  *
+ *  * SPDX-License-Identifier: EPL-2.0
+ *  *******************************************************************************
+ *
+ */
+// ninja2 like template engine
+var { Liquid } = require('liquidjs')
+let templateEngine = new Liquid()
+
+/**
+  * Object in depth traversal and right value templateEngine rendering
+  * @param {*} subjects
+  * @param {*} templateContext
+  */
+const rvaluesVarSubstition = async (subjects, templateContext) => {
+  Object.keys(subjects).forEach((key) => {
+    if (typeof subjects[key] === 'object') {
+      rvaluesVarSubstition(subjects[key], templateContext)
+    } else if (typeof subjects[key] === 'string') {
+      subjects[key] = templateEngine.parseAndRenderSync(subjects[key], templateContext)
+    }
+  })
+  return subjects
+}
+
+
+
+module.exports = {
+  rvaluesVarSubstition
+}

--- a/src/server.js
+++ b/src/server.js
@@ -28,7 +28,7 @@ const { renderFile } = require('ejs')
 const xss = require('xss-clean')
 const packageJson = require('../package')
 
-const { rvaluesVarSubstition } = require( './helpers/template-helper')  
+const { rvaluesVarSubstition } = require('./helpers/template-helper')
 const viewerApp = express()
 
 const app = express()
@@ -82,10 +82,7 @@ app.use((req, res, next) => {
 // TODO: Template expansion for not for all
 app.use((req, res, next) => {
   if (['POST', 'PUT'].indexOf(req.method) > -1) {
-    logger.error(req.body)
-    logger.error(req.body.name)
     rvaluesVarSubstition(req.body, { self: req.body })
-    logger.error(req.body)
   }
   next()
 })

--- a/src/server.js
+++ b/src/server.js
@@ -28,6 +28,7 @@ const { renderFile } = require('ejs')
 const xss = require('xss-clean')
 const packageJson = require('../package')
 
+const { rvaluesVarSubstition } = require( './helpers/template-helper')  
 const viewerApp = express()
 
 const app = express()
@@ -75,6 +76,17 @@ app.use((req, res, next) => {
   }
 
   res.append('X-Timestamp', Date.now())
+  next()
+})
+
+// TODO: Template expansion for not for all
+app.use((req, res, next) => {
+  if (['POST', 'PUT'].indexOf(req.method) > -1) {
+    logger.error(req.body)
+    logger.error(req.body.name)
+    rvaluesVarSubstition(req.body, { self: req.body })
+    logger.error(req.body)
+  }
   next()
 })
 

--- a/test/src/template/app.yml
+++ b/test/src/template/app.yml
@@ -1,0 +1,60 @@
+
+---
+apiVersion: iofog.org/v2
+kind: Application
+metadata:
+  name: edai-smartbuilding-rules-engine
+spec:
+  microservices:
+    - name: rulesengine
+      agent:
+        name: agent-aismall01
+        config: {} 
+      images:
+        x86: nodered/node-red:latest
+        arm: nodered/node-red:latest
+        registry: remote
+      config: {} 
+      container:
+        rootHostAccess: false 
+        volumes: [] 
+        ports:
+          - internal: 1881
+            external: 1882
+        env:  
+          - key: selfname
+            value: "{{ self.metadata.name }}"
+          - key: sharedToken
+            value: "sekrittoken"
+          - key: http_proxy
+            value: "http://proxy.rd.francetelecom.fr:8080/"
+          - key: https_proxy
+            value: "{{ self.spec.microservices | where: \"name\", \"rulesengine\" | first | map: \"container\" | first | map: \"env\" | first | where: \"key\" , \"http_proxy\" | first | map: \"value\" | first }}"
+    - name: ms2
+      agent:
+        name: agent-aismall01
+        config: {} 
+      images:
+        x86: nodered/img1
+        arm: nodered/img2
+        registry: remote
+      config: {} 
+      container:
+        rootHostAccess: false 
+        volumes: [] 
+        ports:
+          - internal: 1883
+            external: 1884
+        env:  
+          - key: selfname
+            value: "{{ self.metadata.name }}"
+          - key: sharedToken
+            value: "{{ self.spec.microservices | where: \"name\", \"rulesengine\" | first | map: \"container\" | first | map: \"env\" | first | where: \"key\", \"sharedToken\" | first | map: \"value\" | first }}"
+          - key: http_proxy
+            value: "{{ self.spec.microservices | where: \"name\", \"rulesengine\" | first | map: \"container\" | first | map: \"env\" | first | where: \"key\", \"http_proxy\" | first | map: \"value\" | first }}"
+          - key: https_proxy
+            value: "{{ self.spec.microservices | where: \"name\", \"rulesengine\" | first | map: \"container\" | first | map: \"env\" | first | where: \"key\", \"http_proxy\" | first | map: \"value\" | first }}"
+          - key: rulesengineHOST
+            value: "TODO"
+          - key: rulesenginePORT
+            value: "{{ self.spec.microservices | where: \"name\", \"rulesengine\" | first | map: \"container\" | first | map: \"ports\" | first | map: \"external\" | first }}"

--- a/test/src/template/simple.yml
+++ b/test/src/template/simple.yml
@@ -1,0 +1,20 @@
+
+---
+apiVersion: iofog.org/v2
+kind: Application
+metadata:
+  name: edai-smartbuilding-rules-engine
+spec:
+  microservices:
+    - name: rulesengine
+      container:
+        rootHostAccess: false 
+        volumes: [] 
+        ports:
+          - internal: 1881
+            external: 1882
+        env:  
+          - key: selfname
+            value: "{{ self.metadata.name }}"
+          - key: selfnameU
+            value: "{{ self.metadata.name | upcase }}"

--- a/test/src/template/template-test.js
+++ b/test/src/template/template-test.js
@@ -1,0 +1,71 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const yaml = require('js-yaml')
+const fs = require('fs')
+const path = require('path')
+
+const { rvaluesVarSubstition } = require('../../../src/helpers/template-helper')
+
+const lget = require('lodash').get
+
+describe('rvalues variable substition and scripting', () => {
+
+  async function subsForFileName(filename, context = {} ) {
+    // Get document, or throw exception on error
+    let doc = yaml.safeLoad(fs.readFileSync(path.join(__dirname, filename), 'utf8'))
+    Object.assign( context, { self: doc } )
+    // console.log('source doc: %j', doc)
+    let response = await rvaluesVarSubstition(doc, context)
+
+    // console.log('subs: %j', response)
+    return response
+  }
+
+  describe('yaml source parsed to json', () => {
+    def('context', () => {})
+    def('subject', () => subsForFileName($filename, $context))
+
+    context('basic substitution', async () => {
+      def('filename', () => ('./simple.yml'))
+      it('not change the type of attribute value withoug template expression', async () => {
+        let subs = await $subject
+        expect(subs.spec.microservices[0].container.ports[0].external).to.be.a('number').and.equal(1882)
+        expect(subs.spec.microservices[0].container.rootHostAccess).to.be.a('boolean').and.equal(false)
+        expect(subs.spec.microservices[0].container.volumes).to.be.an('array').that.is.empty
+      })
+      it('not change values without template expression', async () => {
+        let subs = await $subject
+        expect(subs.kind).equal('Application')
+      })
+      it('replaces simple variable expressions', async () => {
+        let subs = await $subject
+        expect(subs.spec.microservices[0].container.env.find( el => el.key === 'selfname').value).equal(subs.metadata.name)
+      })
+      it('applies filter', async () => {
+        let subs = await $subject
+        expect(subs.spec.microservices[0].container.env.find( el => el.key === 'selfnameU').value).equals(subs.metadata.name.toUpperCase())
+      })
+    })
+  
+    context('simple Application kind substitution', async () => {
+      def('filename', () => ('./app.yml'))
+      it('spreads application name in microservices', async () => {
+        let subs = await $subject
+        expect(subs.spec.microservices[0].container.env.find( el => el.key === 'selfname').value).to.be.a('string').and.equal(subs.metadata.name)
+        expect(subs.spec.microservices[1].container.env.find( el => el.key === 'selfname').value).equal(subs.metadata.name)
+      })
+      it('sets attributes in same object', async () => {
+        let subs = await $subject
+        expect(subs.spec.microservices[0].container.env.find( el => el.key === 'https_proxy').value).equal(subs.spec.microservices[0].container.env.find( el => el.key === 'http_proxy').value)
+      })
+      it('sets attributes from other object',  async () => {
+        let subs = await $subject
+        expect(subs.spec.microservices[1].container.env.find( el => el.key === 'sharedToken').value).equal(subs.spec.microservices[0].container.env.find( el => el.key === 'sharedToken').value)
+        expect(subs.spec.microservices[1].container.env.find( el => el.key === 'http_proxy').value).equal(subs.spec.microservices[0].container.env.find( el => el.key === 'http_proxy').value)
+        expect(subs.spec.microservices[1].container.env.find( el => el.key === 'https_proxy').value).equal(subs.spec.microservices[0].container.env.find( el => el.key === 'http_proxy').value)
+        expect(subs.spec.microservices[1].container.env.find( el => el.key === 'rulesenginePORT').value).equal(subs.spec.microservices[0].container.ports[0].external.toString())
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!--
********************************************************************************
IMPORTANT: make sure you don't forget to update any applicable documentation
in https://github.com/ioFog/iofog.org/tree/master/content/docs/next
********************************************************************************
Thank you for your contribution!
Code of Conduct: https://iofog.org/docs/contributing/code-of-conduct.html
-->

### Description

Early stage development for template engine based on liquidjs. see https://github.com/franckOL/Controller/issues/1 .

The first version has only a self object to help configuration, and it refere to the document itself.
The template engine liquidjs is used for all POST, PUT verbs for all API routes.

Next improvements:
- [ ] only apply on precise route: routes use by agent don't need that
- [ ]  Add all controller applications to context of template rendering (lazy loading)
- [ ]  Add all controller edge ressources to context of template rendering (lazy loading)
- [ ]  Add all controller agent to context of template rendering (lazy loading)