### PR TITLE
Allow to configure the PID base directory

### DIFF
--- a/src/daemon.js
+++ b/src/daemon.js
@@ -13,11 +13,12 @@
 
 const daemonize = require('daemonize2')
 const logger = require('./logger')
+const path = require('path')
 
 const daemon = daemonize.setup({
   main: 'server.js',
   name: 'iofog-controller',
-  pidfile: 'iofog-controller.pid',
+  pidfile: path.join(process.env.PID_BASE || __dirname, 'iofog-controller.pid'),
   argv: [ ...process.argv.slice(2), 'daemonize2' ],
   silent: true
 })

--- a/src/server.js
+++ b/src/server.js
@@ -198,7 +198,8 @@ const initState = async () => {
     // Store PID to let deamon know we are running.
     jobs.push({
       run: () => {
-        const pidFile = path.join(__dirname, 'iofog-controller.pid')
+        const pidFile = path.join((process.env.PID_BASE || __dirname), 'iofog-controller.pid')
+        logger.info(`==> PID file: ${pidFile}`)
         fs.writeFileSync(pidFile, process.pid)
       }
     })


### PR DESCRIPTION
Signed-off-by: Jens Reimann <jreimann@redhat.com>

<!--
********************************************************************************
IMPORTANT: make sure you don't forget to update any applicable documentation
in https://github.com/ioFog/iofog.org/tree/master/content/docs/next
********************************************************************************
Thank you for your contribution!
Code of Conduct: https://iofog.org/docs/contributing/code-of-conduct.html
-->

- Does the iofog.org or README.md documentation need to change?
  - [ ] Yes <!-- include PR link -->
  - [X] No

### Description

Allow to configure the PID base directory using the env-var `PID_BASE`.