### PR TITLE
chore: bump embedded EdgeOps Console to v1.0.12 and refresh UBI digest.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ NODE_ENV=development
 
 # EdgeOps Console static embed (npm run build:console → dev/console/build)
 EDGEOPS_CONSOLE_PATH=dev/console/build  # must be absolute path
-EDGEOPS_CONSOLE_VERSION=v1.0.11
+EDGEOPS_CONSOLE_VERSION=v1.0.12
 # EDGEOPS_CONSOLE_REPO=https://github.com/Datasance/edgeops-console
 # EDGEOPS_CONSOLE_FLAVOR=datasance
 

--- a/.github/actions/set-build-env/action.yml
+++ b/.github/actions/set-build-env/action.yml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       run: |
         VERSION="${{ env.EDGEOPS_CONSOLE_VERSION }}"
-        if [ -z "$VERSION" ]; then VERSION="1.0.11"; fi
+        if [ -z "$VERSION" ]; then VERSION="1.0.12"; fi
         echo "EDGEOPS_CONSOLE_VERSION=$VERSION" >> "${GITHUB_ENV}"
 
         REPO="${{ env.EDGEOPS_CONSOLE_REPO }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
 
-## [v3.8.2] - 2026-07-23
+## [v3.8.2] - 2026-07-25
 
-Plan 21: liveness/readiness probe split and structured agent auth errors (coordinate with Edgelet v3.8.2). Also embedded OAuth logout/re-login hardening, EdgeOps Console **v1.0.11**, and operator sizing docs.
+Plan 21: liveness/readiness probe split and structured agent auth errors (coordinate with Edgelet v3.8.2). Also embedded OAuth logout/re-login hardening, EdgeOps Console **v1.0.12**, and operator sizing docs.
 
 ### Added
 
@@ -16,7 +16,7 @@ Plan 21: liveness/readiness probe split and structured agent auth errors (coordi
 - **`GET /api/v3/status`** — public **readiness** probe: verifies database, vault (if enabled), and embedded auth signing material; returns **503** with **`Retry-After: 5`** when not ready (same JSON fields as before on **200**).
 - **`checkFogToken`** — infrastructure failures map to **503** instead of generic **401**; credential failures return explicit agent auth codes (e.g. **`AGENT_JWT_ALREADY_USED`**).
 - **`iofog-controller` daemon elevation check** uses **`/api/v3/live`** instead of **`/status`**.
-- Embedded **EdgeOps Console** default version **v1.0.10** → **v1.0.11** (Dockerfile, Makefile, CI build env, `.env.example`, `build-console-dev.js`).
+- Embedded **EdgeOps Console** default version **v1.0.10** → **v1.0.12** (Dockerfile, Makefile, CI build env, `.env.example`, `build-console-dev.js`).
 - Embedded OAuth BFF authorize sends **`prompt=login`** so each browser sign-in starts a fresh issuer interaction.
 - **`POST /api/v3/user/logout`** (embedded) clears issuer Session/Grant/Interaction state and destroys the BFF express-session when present (refresh-token revocation unchanged).
 - Dependency bumps: OpenTelemetry **0.221.x**, **`body-parser` 1.20.6**, **`js-yaml` 4.3.0**, **`undici` ^7.28.0**; Dockerfile base image digest pins refreshed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM node:24-bookworm@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059 AS console-builder
 
 ARG EDGEOPS_CONSOLE_REPO=https://github.com/Datasance/edgeops-console
-ARG EDGEOPS_CONSOLE_VERSION=v1.0.11
+ARG EDGEOPS_CONSOLE_VERSION=v1.0.12
 ARG EDGEOPS_CONSOLE_FLAVOR=datasance
 
 RUN apt-get update \
@@ -48,9 +48,9 @@ RUN npm pack
 
 
 # ubi9/nodejs-24-minimal:latest — pin manifest list digest for reproducible multi-arch builds
-FROM registry.access.redhat.com/ubi9/nodejs-24-minimal@sha256:a2645b0523c33d19055cc59e1819beb4d32b2c24e3f6ef231e7b5526fb2c1f01
+FROM registry.access.redhat.com/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1
 
-ARG EDGEOPS_CONSOLE_VERSION=v1.0.11
+ARG EDGEOPS_CONSOLE_VERSION=v1.0.12
 ARG IMAGE_REGISTRY
 ARG OCI_SOURCE_REPO
 ARG CONTROLLER_DISTRIBUTION=iofog

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Local Docker build — mirrors CI/release build-args (see .github/actions/set-build-env).
-# Override any variable: make build FLAVOR=iofog EDGEOPS_CONSOLE_VERSION=v1.0.11
+# Override any variable: make build FLAVOR=iofog EDGEOPS_CONSOLE_VERSION=v1.0.12
 
 FLAVOR ?= datasance
 IMAGE_NAME ?= controller
@@ -25,7 +25,7 @@ else
   $(error FLAVOR must be "datasance" or "iofog", got "$(FLAVOR)")
 endif
 
-EDGEOPS_CONSOLE_VERSION ?= v1.0.11
+EDGEOPS_CONSOLE_VERSION ?= v1.0.12
 
 IMAGE_REF = $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(DOCKER_TAG)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3888,15 +3888,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browser-stdout": {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "tar": "^7.5.19",
     "protobufjs": "^7.6.5",
     "js-yaml": "4.3.0",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "uuid": "11.1.1",
     "diff": "8.0.3",
     "serialize-javascript": "7.0.5"

--- a/scripts/build-console-dev.js
+++ b/scripts/build-console-dev.js
@@ -9,7 +9,7 @@ const CONSOLE_DIR = path.join(DEV_DIR, 'console')
 const BUILD_OUT = path.join(CONSOLE_DIR, 'build')
 
 const REPO = process.env.EDGEOPS_CONSOLE_REPO || 'https://github.com/Datasance/edgeops-console'
-const VERSION = process.env.EDGEOPS_CONSOLE_VERSION || 'v1.0.11'
+const VERSION = process.env.EDGEOPS_CONSOLE_VERSION || 'v1.0.12'
 const FLAVOR = process.env.EDGEOPS_CONSOLE_FLAVOR || 'datasance'
 
 function normalizeTag (version) {


### PR DESCRIPTION
Align Dockerfile, Makefile, CI, and dev build defaults with Console v1.0.12; update v3.8.2 changelog and brace-expansion 5.0.8.