### PR TITLE
chore: refresh Dockerfile digest pins for v3.8.3-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog
 
 
-## [v3.8.3] - August 2026
+## [v3.8.3-rc.2] - August 2026
+
+Docker image digest pin refresh for reproducible multi-arch builds.
+
+### Changed
+
+- Dockerfile base image digest pins refreshed for **`node:24-bookworm`** (console-builder and builder stages) and **`ubi9/nodejs-24-minimal`**.
+
+
+## [v3.8.3-rc.1] - August 2026
 Security patch release: resolve npm audit findings across transitive and direct dependencies. No API or operator-facing behavior changes intended.
 ### Changed
 - **`js-yaml` 4.3.0 → 4.3.1** — address GHSA-5p4m-2wfm-xmqj (quadratic CPU consumption in `!!omap` resolution).
@@ -472,9 +481,8 @@ No changes
 ## [1.0.0](https://github.com/ioFog/Controller/releases/tag/1.0.0) (2018-10-30)
 
 
-[v2.0.0-rc1]:   https://github.com/eclipse-iofog/helm/compare/v2.0.0-rc1..v2.0.0-beta2
-[v2.0.0-beta2]: https://github.com/eclipse-iofog/helm/compare/v2.0.0-beta2..v2.0.0-beta
-[v2.0.0-beta]:  https://github.com/eclipse-iofog/helm/compare/v2.0.0-beta..v2.0.0-alpha
-[v2.0.0-alpha]: https://github.com/eclipse-iofog/helm/compare/v2.0.0-alpha..v1.3.0
-[v1.2.1]: https://github.com/eclipse-iofog/helm/compare/v1.2.1..v1.1.1
-[v1.1.1]: https://github.com/eclipse-iofog/helm/releases/tag/v1.1.1
+[v3.8.3-rc.2]: https://github.com/eclipse-iofog/Controller/compare/v3.8.3-rc.1...v3.8.3-rc.2
+[v3.8.3-rc.1]: https://github.com/eclipse-iofog/Controller/compare/v3.8.2...v3.8.3-rc.1
+[v3.8.2]:      https://github.com/eclipse-iofog/Controller/compare/v3.8.1...v3.8.2
+[v3.8.1]:      https://github.com/eclipse-iofog/Controller/compare/v3.8.0...v3.8.1
+[v3.8.0]:      https://github.com/eclipse-iofog/Controller/releases/tag/v3.8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # ioFog overrides: EDGEOPS_CONSOLE_REPO=https://github.com/eclipse-iofog/edgeops-console
 #                   EDGEOPS_CONSOLE_FLAVOR=iofog
 # node:24-bookworm — pin manifest list digest for reproducible multi-arch builds
-FROM node:24-bookworm@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584 AS console-builder
+FROM node:24-bookworm@sha256:4196d66a565c6f195728d9952f161f4adfe2ad753052a08b7ec7f1c5a6bda42b AS console-builder
 
 ARG EDGEOPS_CONSOLE_REPO=https://github.com/Datasance/edgeops-console
 ARG EDGEOPS_CONSOLE_VERSION=v1.0.13
@@ -28,7 +28,7 @@ RUN test -f build/index.html \
     && cp -a build /tmp/console/build
 
 
-FROM node:24-bookworm@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584 AS builder
+FROM node:24-bookworm@sha256:4196d66a565c6f195728d9952f161f4adfe2ad753052a08b7ec7f1c5a6bda42b AS builder
 
 ARG PKG_VERSION
 
@@ -48,7 +48,7 @@ RUN npm pack
 
 
 # ubi9/nodejs-24-minimal:latest — pin manifest list digest for reproducible multi-arch builds
-FROM registry.access.redhat.com/ubi9/nodejs-24-minimal@sha256:83d187c1096fef19fc43dc94cba75860706ba268d123c85e33a3c375e9bd6271
+FROM registry.access.redhat.com/ubi9/nodejs-24-minimal@sha256:b65d9acb66bf446040c91925f245ee2e9d9873c966ed3eb0a87e23ed3ca12786
 
 ARG EDGEOPS_CONSOLE_VERSION=v1.0.13
 ARG IMAGE_REGISTRY


### PR DESCRIPTION
Update node:24-bookworm and ubi9/nodejs-24-minimal manifest list digests; add v3.8.3-rc.2 CHANGELOG entry and fix version footer links.