### PR TITLE
deps: bump mysql2 to 3.24.3 (GHSA-3f6p-5ww8-9rcr, GHSA-rgwj-5xj2-c3m3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "jsonschema": "1.5.0",
         "moment": "2.30.1",
         "multer": "2.2.0",
-        "mysql2": "3.10.1",
+        "mysql2": "3.24.3",
         "nconf": "0.12.1",
         "node-fetch-npm": "^2.0.4",
         "node-forge": "^1.4.0",
@@ -3555,6 +3555,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
@@ -4823,15 +4832,6 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT"
-    },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -9205,15 +9205,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lru-cache": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
-      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
     "node_modules/lru-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
@@ -9642,34 +9633,37 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.1.tgz",
-      "integrity": "sha512-6zo1T3GILsXMCex3YEu7hCz2OXLUarxFsxvFcUHWMpkPtmZLeTTWgRdc1gWyNJiYt6AxITmIf9bZDRy/jAfWew==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "license": "MIT",
       "dependencies": {
-        "denque": "^2.1.0",
+        "aws-ssl-profiles": "^1.1.2",
         "generate-function": "^2.3.1",
-        "iconv-lite": "^0.6.3",
-        "long": "^5.2.1",
-        "lru-cache": "^8.0.0",
-        "named-placeholders": "^1.1.3",
-        "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.2"
+        "iconv-lite": "^0.7.3",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"
       }
     },
     "node_modules/mysql2/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/named-placeholders": {
@@ -12003,11 +11997,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/seq-queue": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
-    },
     "node_modules/sequelize": {
       "version": "6.37.8",
       "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.37.8.tgz",
@@ -12642,6 +12631,21 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/sql-escaper": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
     "node_modules/sqlite3": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-6.0.1.tgz",
@@ -12667,15 +12671,6 @@
         "node-gyp": {
           "optional": true
         }
-      }
-    },
-    "node_modules/sqlstring": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
-      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/standard": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "jsonschema": "1.5.0",
     "moment": "2.30.1",
     "multer": "2.2.0",
-    "mysql2": "3.10.1",
+    "mysql2": "3.24.3",
     "@nats-io/transport-node": "^3.4.0",
     "nconf": "0.12.1",
     "node-fetch-npm": "^2.0.4",


### PR DESCRIPTION
Updates `mysql2` to address GHSA-3f6p-5ww8-9rcr and GHSA-rgwj-5xj2-c3m3.

Evidence:
- `package.json` and `package-lock.json` pinned `mysql2@3.10.1`
- osv-scanner reported GHSA-3f6p-5ww8-9rcr (auth plugin downgrade to mysql_clear_password, fixed in 3.22.0) and GHSA-rgwj-5xj2-c3m3 (DoS with compress: true, fixed in 3.23.1) against 3.10.1
- updated version: `3.24.3`

Validation:
- osv-scanner no longer reports either mysql2 advisory after the update
- `npm test` (unit suite, 1216 tests) passes, same as on develop before the change. Run with `npm ci --legacy-peer-deps`, `npm rebuild sqlite3 --build-from-source`, and `LOG_DIRECTORY=/tmp/iofog-controller-logs`, matching .github/workflows/quality.yml. Local node is 22 instead of the workflow's 24; tests pass on both the base commit and this branch in the same environment

Note: osv-scanner still reports two separate advisories for browserslist 4.28.2 (GHSA-73wf-gq98-2v4g, GHSA-c83g-rgw3-j3cx), a dev dependency untouched by this patch.

Scope: dependency/lockfile update only (`package.json`, `package-lock.json`).
